### PR TITLE
Add 'khí công' domain to available domains list

### DIFF
--- a/client/src/constants/domains.ts
+++ b/client/src/constants/domains.ts
@@ -15,5 +15,6 @@ export const availableDomains = [
   'phong thủy',
   'đạo phật',
   'thích nhất hạnh',
-  'viên minh'
-]; 
+  'viên minh',
+  'khí công'
+];


### PR DESCRIPTION
## Summary

Adds 'khí công' to the list of available knowledge domains for document processing and YouTube transcript analysis.

## Changes Made

- Added 'khí công' to the `availableDomains` array in `client/src/constants/domains.ts`
- This domain will now be available for selection in both YouTube transcript processing and document upload workflows

## Impact

- Users can now select 'khí công' as a knowledge domain when:
  - Processing YouTube video transcripts
  - Uploading and processing documents
- The change automatically applies to both `YoutubeUpload` and `DocumentUpload` components since they dynamically render domains from the `availableDomains` array
- No backend changes required as the system already supports dynamic domains

## Testing

- ✅ Verified that the domain appears in the UI components
- ✅ Confirmed that existing functionality remains unchanged
- ✅ No breaking changes introduced

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author