### PR TITLE
Fix: Improve MP4 quality selection in yt-dlp downloader

### DIFF
--- a/client/src/components/YtDlpDownloader.tsx
+++ b/client/src/components/YtDlpDownloader.tsx
@@ -553,17 +553,40 @@ const YtDlpDownloader = ({ onUploadSuccess }: { onUploadSuccess: () => void }) =
               onChange={(e) => setDownloadOptions(prev => ({ ...prev, quality: e.target.value }))}
               className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
             >
-              <option value="auto">Auto (yt-dlp default) - Usually MKV</option>
-              <option value="best[ext=mkv]">Best Quality (MKV Only) - Force MKV</option>
-              <option value="best[ext=mkv]/best">Best Quality (MKV Preferred)</option>
-              <option value="best[ext=mp4]/best">Best Quality (MP4)</option>
-              <option value="best[ext=mkv][height<=1080]">1080p MKV Only</option>
-              <option value="best[ext=mkv][height<=720]">720p MKV Only</option>
-              <option value="worst[ext=mp4]/worst">Worst Quality (MP4)</option>
-              <option value="best[height<=720]">720p or lower</option>
-              <option value="best[height<=480]">480p or lower</option>
-              <option value="best[height<=360]">360p or lower</option>
+              <option value="auto">🎯 Auto (Highest Quality) - Usually MKV/WebM</option>
+              <option value="best[ext=mkv]">🏆 Best Quality (MKV Only) - Force MKV</option>
+              <option value="best[ext=mkv]/best">🥇 Best Quality (MKV Preferred)</option>
+              <option value="bestvideo[ext=mp4]+bestaudio[ext=m4a]">📱 Best MP4 Quality (Separate Streams)</option>
+              <option value="best[ext=mp4]/best">📱 Best MP4 (May be lower quality)</option>
+              <option value="best[ext=mkv][height<=1440]">🎬 1440p MKV Only</option>
+              <option value="best[ext=mkv][height<=1080]">📺 1080p MKV Only</option>
+              <option value="best[ext=mkv][height<=720]">📱 720p MKV Only</option>
+              <option value="best[ext=mp4][height<=1080]">📱 1080p MP4 Only</option>
+              <option value="best[ext=mp4][height<=720]">📱 720p MP4 Only</option>
+              <option value="worst[ext=mp4]/worst">⚡ Smallest File (MP4)</option>
+              <option value="best[height<=720]">📱 720p or lower (Any format)</option>
+              <option value="best[height<=480]">📱 480p or lower (Any format)</option>
+              <option value="best[height<=360]">📱 360p or lower (Any format)</option>
             </select>
+            <div className="mt-2 text-sm text-gray-600">
+              <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
+                <div className="flex items-start">
+                  <div className="flex-shrink-0">
+                    <svg className="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor">
+                      <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                    </svg>
+                  </div>
+                  <div className="ml-3">
+                    <h4 className="text-sm font-medium text-blue-800">Quality Guide</h4>
+                    <div className="mt-1 text-sm text-blue-700">
+                      <p><strong>Highest Quality:</strong> Auto or MKV options (may use VP9/AV1 codecs)</p>
+                      <p><strong>MP4 Compatibility:</strong> MP4 options prioritize compatibility but may have lower quality than MKV/WebM</p>
+                      <p><strong>Best MP4:</strong> "Separate Streams" option provides highest quality MP4 by merging best video + audio</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
 
           {/* Audio Options */}

--- a/server/src/services/yt-dlp-downloader.ts
+++ b/server/src/services/yt-dlp-downloader.ts
@@ -240,15 +240,35 @@ const getFormatFallbacks = (options: YtDlpDownloadOptions): string[] => {
     }
   }
 
+  // If user specifically requested MP4, provide better MP4 fallbacks
+  const userWantsMp4 = options.quality?.includes('mp4') || options.format?.includes('mp4');
+
+  if (userWantsMp4) {
+    // Add comprehensive MP4-specific options before falling back to other formats
+    const mp4Fallbacks = [
+      'bestvideo[ext=mp4]+bestaudio[ext=m4a]', // Best MP4 video + M4A audio (highest quality MP4 combo)
+      'bestvideo[ext=mp4]+bestaudio',          // Best MP4 video + any audio
+      'best[ext=mp4]',                         // Best single-file MP4 (may be lower quality)
+      'best[ext=mp4][height<=1440]',           // MP4 up to 1440p
+      'best[ext=mp4][height<=1080]',           // MP4 up to 1080p
+      'best[ext=mp4][height<=720]',            // MP4 up to 720p
+    ];
+
+    for (const format of mp4Fallbacks) {
+      if (!fallbackFormats.includes(format)) {
+        fallbackFormats.push(format);
+      }
+    }
+  }
+
   // Add comprehensive fallback options (avoiding duplicates)
   const standardFallbacks = [
-    'best[ext=mp4][height<=1080]',           // Prefer MP4, max 1080p
-    'best[ext=mp4]',                         // Any MP4 quality
+    'bestvideo+bestaudio/best',              // Best separate streams or combined (highest quality)
+    'best[height<=1440]',                    // Max 1440p, any format
     'best[height<=1080]',                    // Max 1080p, any format
     'best[height<=720]',                     // Max 720p, any format
     'bestvideo[height<=1080]+bestaudio',     // Separate streams, max 1080p
     'bestvideo[height<=720]+bestaudio',      // Separate streams, max 720p
-    'bestvideo+bestaudio/best',              // Best separate streams or combined
     'best[protocol!=m3u8]',                  // Best non-HLS format
     'best',                                  // Best available quality, any format
     'bestvideo+bestaudio',                   // Any separate video+audio streams


### PR DESCRIPTION
## Problem

The "best MP4" option wasn't actually providing the best quality because:

- YouTube's highest quality formats (1440p, 4K, newer content) are primarily available in **WebM/MKV** containers with **VP9** or **AV1** codecs
- When selecting `best[ext=mp4]`, yt-dlp is forced to skip these higher quality formats and fall back to older **H.264** formats in MP4 containers
- The previous fallback logic even limited MP4 to 1080p first before trying higher resolutions in other formats

## Solution

### Backend Improvements
- ✅ Added better MP4 format fallbacks with `bestvideo[ext=mp4]+bestaudio[ext=m4a]` as the top MP4 option
- ✅ This merges the best separate video and audio streams for much higher quality than single-file MP4 formats
- ✅ Added comprehensive MP4-specific fallbacks before falling back to other formats
- ✅ Improved overall fallback logic to prioritize quality

### Frontend Improvements
- ✅ Added new "Best MP4 Quality (Separate Streams)" option for highest quality MP4
- ✅ Added emojis and clearer descriptions to quality selector options
- ✅ Added helpful quality guide explaining format differences and trade-offs
- ✅ Made it clear that "Auto" provides absolute highest quality

## Key Changes

### Backend (`server/src/services/yt-dlp-downloader.ts`)
- Added MP4-specific fallback logic when user requests MP4 formats
- Prioritizes `bestvideo[ext=mp4]+bestaudio[ext=m4a]` for best MP4 quality
- Improved overall fallback order to prioritize quality over format restrictions

### Frontend (`client/src/components/YtDlpDownloader.tsx`)
- Enhanced quality selector with better options and descriptions
- Added informational guide about quality vs compatibility trade-offs
- Visual improvements with emojis and clearer labeling

## Result

**For maximum quality**: Use "Auto" or MKV options (gets VP9/AV1 formats)
**For MP4 compatibility**: Use "Best MP4 Quality (Separate Streams)" for the highest quality MP4 possible

Users now get significantly better MP4 quality while understanding the trade-offs between format compatibility and video quality.

## Testing

- [x] Verified format fallback logic works correctly
- [x] Tested UI improvements and quality guide display
- [x] Confirmed MP4 downloads now get higher quality streams

Fixes the issue where MP4 downloads were not getting the best available quality.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author