### PR TITLE
Prepare client for Qdrant server v1.19.0 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,12 @@ server/downloads/
 # Qdrant storage
 qdrant_storage/
 
+# Collection dumps from `npm run backup export` — these contain document
+# content and vectors, so they must never be committed.
+backups/
+*.jsonl
+*.meta.json
+
 # Data directories
 /server/data/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,11 @@
-version: '3.8'
-
 services:
   qdrant:
-    image: qdrant/qdrant
+    image: qdrant/qdrant:v1.19.0
     ports:
       - "6333:6333"
       - "6334:6334"
     volumes:
       - ./qdrant_storage:/qdrant/storage
-    environment:
-      - QDRANT_ENABLE_FASTEMBED=true
     restart: always
 
   server:
@@ -21,9 +17,14 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
-      - QDRANT_URL=http://qdrant:6333
-      - QDRANT_COLLECTION_NAME=documents
-      - VECTOR_SIZE=384
+      # Point at the local qdrant service by default; override to target Qdrant Cloud.
+      - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
+      - QDRANT_API_KEY=${QDRANT_API_KEY:-}
+      - COLLECTION_NAME=${COLLECTION_NAME:-knowledge_base}
+      # Must match the Gemini embedding model's output size and the existing
+      # collection's vector size. Changing this on a populated collection breaks upserts.
+      - GEMINI_VECTOR_SIZE=${GEMINI_VECTOR_SIZE:-768}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
     depends_on:
       - qdrant
     volumes:

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.env
+.env.*
+uploads
+downloads
+temp
+data
+*.log
+.DS_Store

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:16-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 COPY . .
 RUN npm run build

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,7 +13,7 @@
         "@google-cloud/vision": "^4.3.3",
         "@google/genai": "^1.11.0",
         "@google/generative-ai": "^0.2.1",
-        "@qdrant/js-client-rest": "^1.6.0",
+        "@qdrant/js-client-rest": "^1.19.0",
         "axios": "^1.9.0",
         "cheerio": "^1.0.0",
         "cors": "^2.8.5",
@@ -43,6 +43,9 @@
         "ts-node-dev": "^2.0.0",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.1.6"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -100,23 +103,6 @@
         "undici": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@distube/ytdl-core/node_modules/undici": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
-      "integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@google-cloud/common": {
@@ -746,17 +732,16 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@qdrant/js-client-rest": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.13.0.tgz",
-      "integrity": "sha512-bewMtnXlGvhhnfXsp0sLoLXOGvnrCM15z9lNlG0Snp021OedNAnRtKkerjk5vkOcbQWUmJHXYCuxDfcT93aSkA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.19.0.tgz",
+      "integrity": "sha512-1+QLUHsWp+WV4PE35FLnH2ckxotWrQEqi/F3t4goF3cCThR0ZxLVtOC4OoOi/E1iyj/iIYBdbuACWMuQ15NAnA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@qdrant/openapi-typescript-fetch": "1.2.6",
-        "@sevinf/maybe": "0.5.0",
-        "undici": "~5.28.4"
+        "undici": "7.29.0"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "pnpm": ">=8"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "typescript": ">=4.7"
@@ -770,11 +755,6 @@
         "node": ">=18.0.0",
         "pnpm": ">=8"
       }
-    },
-    "node_modules/@sevinf/maybe": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@sevinf/maybe/-/maybe-0.5.0.tgz",
-      "integrity": "sha512-ARhyoYDnY1LES3vYI0fiG6e9esWfTNcXcO6+MPJJXcnyMV3bim4lnFt45VXouV7y82F4x3YH8nOQ6VztuvUiWg=="
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -4165,14 +4145,12 @@
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/server/package.json
+++ b/server/package.json
@@ -4,6 +4,9 @@
   "description": "Server for document processing and vector storage",
   "type": "commonjs",
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
@@ -17,7 +20,7 @@
     "@google-cloud/vision": "^4.3.3",
     "@google/genai": "^1.11.0",
     "@google/generative-ai": "^0.2.1",
-    "@qdrant/js-client-rest": "^1.6.0",
+    "@qdrant/js-client-rest": "^1.19.0",
     "axios": "^1.9.0",
     "cheerio": "^1.0.0",
     "cors": "^2.8.5",

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,8 @@
     "start": "node dist/index.js",
     "dev": "ts-node-dev --respawn -r tsconfig-paths/register src/index.ts",
     "dev:debug": "ts-node -r tsconfig-paths/register --inspect src/index.ts",
-    "migrate": "ts-node -r tsconfig-paths/register src/scripts/migrate.ts"
+    "migrate": "ts-node -r tsconfig-paths/register src/scripts/migrate.ts",
+    "backup": "ts-node -r tsconfig-paths/register src/scripts/backup.ts"
   },
   "dependencies": {
     "@distube/ytdl-core": "^4.16.12",

--- a/server/src/core/database-service.ts
+++ b/server/src/core/database-service.ts
@@ -231,13 +231,13 @@ export class DatabaseService {
       },
       // Qdrant function
       async () => {
-        const results = await this.qdrantClient.search(COLLECTION_NAME, {
-          vector: queryVector,
+        const results = await this.qdrantClient.query(COLLECTION_NAME, {
+          query: queryVector,
           limit: limit,
           with_payload: true
         });
 
-        return results.map(hit => {
+        return results.points.map(hit => {
           const payload = hit.payload as any;
 
           return {

--- a/server/src/scripts/backup.ts
+++ b/server/src/scripts/backup.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Version-agnostic collection backup / restore.
+ *
+ * Why this exists: Qdrant Cloud's managed Backups feature is not available on
+ * free clusters, and a Qdrant *snapshot* can only be restored into a cluster
+ * running the same minor version — so a snapshot taken on 1.13.5 cannot be
+ * restored into anything but 1.13.x.
+ *
+ * This script instead dumps points as plain JSONL (id + vector + payload) and
+ * re-inserts them through the ordinary upsert API. That data is not tied to any
+ * storage format, so it can be restored into ANY Qdrant version. It is the only
+ * rollback path that survives an upgrade you cannot undo.
+ *
+ * Usage:
+ *   npm run backup export                        # dump the configured collection
+ *   npm run backup export -- --out ./backups     # choose an output directory
+ *   npm run backup restore -- --file <path.jsonl> --collection <name> --confirm
+ *
+ * Export is read-only. Restore refuses to touch an existing collection unless
+ * --force is passed, and never runs without --confirm.
+ */
+
+import { QdrantClient } from '@qdrant/js-client-rest';
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+
+dotenv.config();
+
+const QDRANT_URL = process.env.QDRANT_URL || 'http://localhost:6333';
+const QDRANT_API_KEY = process.env.QDRANT_API_KEY;
+const COLLECTION_NAME = process.env.COLLECTION_NAME || 'knowledge_base';
+
+// Free-tier clusters are 0.5 vCPU; keep batches small so export/restore does not
+// starve the live service.
+const SCROLL_BATCH = 100;
+const UPSERT_BATCH = 100;
+
+const client = new QdrantClient({ url: QDRANT_URL, apiKey: QDRANT_API_KEY });
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+function flag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+async function serverVersion(): Promise<string> {
+  try {
+    const res = await fetch(`${QDRANT_URL}/`, {
+      headers: QDRANT_API_KEY ? { 'api-key': QDRANT_API_KEY } : {},
+    });
+    return ((await res.json()) as any).version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function doExport() {
+  const collection = arg('collection') || COLLECTION_NAME;
+  const outDir = arg('out') || './backups';
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const version = await serverVersion();
+  const info: any = await client.getCollection(collection);
+  const expected = (await client.count(collection, { exact: true })).count;
+
+  // Timestamp comes from the filesystem clock, not a hardcoded value, so repeat
+  // runs never overwrite each other.
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const base = path.join(outDir, `${collection}-${stamp}`);
+  const dataFile = `${base}.jsonl`;
+  const metaFile = `${base}.meta.json`;
+
+  console.log(`Source     : ${QDRANT_URL}`);
+  console.log(`Collection : ${collection}`);
+  console.log(`Server     : qdrant ${version}`);
+  console.log(`Points     : ${expected}`);
+  console.log(`Output     : ${dataFile}\n`);
+
+  fs.writeFileSync(
+    metaFile,
+    JSON.stringify(
+      {
+        collection,
+        exportedAt: new Date().toISOString(),
+        qdrantVersion: version,
+        sourceUrl: QDRANT_URL,
+        pointCount: expected,
+        vectors: info.config?.params?.vectors,
+        payloadSchema: info.payload_schema,
+      },
+      null,
+      2
+    )
+  );
+
+  const out = fs.createWriteStream(dataFile);
+  let offset: any = undefined;
+  let written = 0;
+
+  do {
+    const res: any = await client.scroll(collection, {
+      limit: SCROLL_BATCH,
+      offset,
+      with_payload: true,
+      with_vector: true,
+    });
+
+    for (const p of res.points) {
+      out.write(JSON.stringify({ id: p.id, vector: p.vector, payload: p.payload }) + '\n');
+      written++;
+    }
+
+    offset = res.next_page_offset;
+    process.stdout.write(`\r  exported ${written}/${expected}`);
+  } while (offset);
+
+  await new Promise<void>((r) => out.end(r));
+  console.log('\n');
+
+  // A silently short dump is worse than no dump, so fail loudly on a mismatch.
+  if (written !== expected) {
+    console.error(`MISMATCH: expected ${expected} points, wrote ${written}. Backup is INCOMPLETE.`);
+    process.exit(1);
+  }
+
+  const bytes = fs.statSync(dataFile).size;
+  console.log(`OK  ${written} points -> ${dataFile} (${(bytes / 1024 / 1024).toFixed(1)} MB)`);
+  console.log(`OK  metadata          -> ${metaFile}`);
+  console.log(`\nRestore with:\n  npm run backup restore -- --file ${dataFile} --collection ${collection}-restored --confirm`);
+}
+
+async function countLines(file: string): Promise<number> {
+  let n = 0;
+  const rl = readline.createInterface({ input: fs.createReadStream(file), crlfDelay: Infinity });
+  for await (const line of rl) if (line.trim()) n++;
+  return n;
+}
+
+async function doRestore() {
+  const file = arg('file');
+  const target = arg('collection');
+
+  if (!file || !target) {
+    console.error('Usage: npm run backup restore -- --file <path.jsonl> --collection <name> --confirm');
+    process.exit(1);
+  }
+  if (!fs.existsSync(file)) {
+    console.error(`No such file: ${file}`);
+    process.exit(1);
+  }
+
+  const metaFile = file.replace(/\.jsonl$/, '.meta.json');
+  if (!fs.existsSync(metaFile)) {
+    console.error(`Missing metadata file: ${metaFile} (needed for the collection's vector config)`);
+    process.exit(1);
+  }
+  const meta = JSON.parse(fs.readFileSync(metaFile, 'utf8'));
+  const total = await countLines(file);
+  const version = await serverVersion();
+
+  console.log(`Target     : ${QDRANT_URL}`);
+  console.log(`Collection : ${target}`);
+  console.log(`Server     : qdrant ${version}`);
+  console.log(`From       : ${file}`);
+  console.log(`Points     : ${total}  (dump taken on qdrant ${meta.qdrantVersion} from ${meta.sourceUrl})`);
+  console.log(`Vectors    : ${JSON.stringify(meta.vectors)}\n`);
+
+  if (!flag('confirm')) {
+    console.error('Refusing to write without --confirm. Re-run with --confirm once the target above looks right.');
+    process.exit(1);
+  }
+
+  const existing = await client.getCollections();
+  const exists = existing.collections?.some((c) => c.name === target);
+  if (exists && !flag('force')) {
+    console.error(`Collection "${target}" already exists. Pass --force to delete and recreate it.`);
+    process.exit(1);
+  }
+  if (exists) {
+    console.log(`Deleting existing collection "${target}" (--force)`);
+    await client.deleteCollection(target);
+  }
+
+  await client.createCollection(target, { vectors: meta.vectors });
+  for (const field of Object.keys(meta.payloadSchema || {})) {
+    await client.createPayloadIndex(target, {
+      field_name: field,
+      field_schema: meta.payloadSchema[field].data_type,
+    });
+  }
+
+  const rl = readline.createInterface({ input: fs.createReadStream(file), crlfDelay: Infinity });
+  let batch: any[] = [];
+  let done = 0;
+
+  const flush = async () => {
+    if (!batch.length) return;
+    await client.upsert(target, { wait: true, points: batch });
+    done += batch.length;
+    process.stdout.write(`\r  restored ${done}/${total}`);
+    batch = [];
+  };
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    const p = JSON.parse(line);
+    batch.push({ id: p.id, vector: p.vector, payload: p.payload });
+    if (batch.length >= UPSERT_BATCH) await flush();
+  }
+  await flush();
+  console.log('\n');
+
+  const final = (await client.count(target, { exact: true })).count;
+  if (final !== total) {
+    console.error(`MISMATCH: restored ${final} points, expected ${total}.`);
+    process.exit(1);
+  }
+  console.log(`OK  ${final} points restored into "${target}"`);
+}
+
+async function main() {
+  const cmd = process.argv[2];
+  switch (cmd) {
+    case 'export':
+      await doExport();
+      break;
+    case 'restore':
+      await doRestore();
+      break;
+    default:
+      console.log('Commands:');
+      console.log('  export   [--collection <name>] [--out <dir>]');
+      console.log('  restore   --file <path.jsonl> --collection <name> --confirm [--force]');
+      process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error('\nFAILED:', e?.message ?? e);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #86.

Prepares the codebase for the Qdrant server upgrade from v1.13.5 to v1.19.0. Three independently revertable commits.

## Compatibility finding

**The code as it stood was already compatible with server 1.19.0 — no changes were required just to upgrade the server.** Client 1.13.0 can still call `POST /points/search` against 1.19.0; the endpoint was removed from the OpenAPI spec but the handler still serves traffic. The only runtime symptom was two `console.warn` lines per process start, because the client's compat rule is `major equal && |minor diff| <= 1` (`client-version.js:45`) and 13 vs 19 fails it. That check is fire-and-forget — it does not throw.

What *did* break was upgrading the **client library**, which is what this PR handles.

## Commits

**`7625f1d` — `search()` → `query()`**

`@qdrant/js-client-rest@1.19.0` deletes `search()` (plus `searchBatch`/`recommend`/`discover*`). `database-service.ts:234` was the codebase's only `search()` call site. `query()` already exists in 1.13.0 and returns `{points: ScoredPoint[]}` rather than a bare array, so this commit compiles against both versions and could land before any dependency change. Passing a bare `number[]` as `query` is plain nearest-neighbour search — identical semantics. The collection uses a single unnamed vector, so no `using` param is needed.

**`0d41d9e` — client 1.19.0 + Node 22 base image**

`^1.6.0` → `^1.19.0`. Client 1.19.0 declares `engines.node ">=22.0.0"` and pins `undici@7.29.0`, so `server/Dockerfile` moves off `node:16-alpine`.

That base image was *already* below spec independently of Qdrant — `@distube/ytdl-core` needs `>=20.18.1`, `@google/genai` needs `>=20.0.0`. It survived only because npm treats `engines` as advisory. Staying on Node 22 LTS rather than 24 because 1.19.0 pins undici to an exact version, so undici patches arrive only via a qdrant-js release.

Also switches `npm install` → `npm ci` and adds `server/.dockerignore` — `COPY . .` with no ignore file was baking the host's `node_modules` (including darwin native binaries) into the alpine image.

⚠️ **Side effect to watch:** undici hoists to 7.29.0, moving `@distube/ytdl-core` from 7.12.0. Within its declared `^7.8.0` range, but it shifts the HTTP stack under the YouTube download path (`src/services/youtube-downloader.ts`). Kept as its own commit so it can be reverted alone if a YouTube regression appears. The recent 403 fixes (f1ea2db, 231e71d, b5996a2) are all on the yt-dlp path, which does not use undici.

**`737a6e2` — compose pin + dead env vars**

Image was untagged, silently tracking `:latest` (which today already resolves to v1.19.0). Pinned to `v1.19.0` — floating `:latest` on a stateful DB with a one-way storage migration is a hazard.

Three env vars were never read by any code, verified by grepping every `process.env` reference in `server/src`:

| In compose | What the code actually reads |
|---|---|
| `QDRANT_COLLECTION_NAME=documents` | `COLLECTION_NAME` (`database-service.ts:13`) |
| `VECTOR_SIZE=384` | `GEMINI_VECTOR_SIZE` (`database-service.ts:14`, default 768) |
| `QDRANT_ENABLE_FASTEMBED=true` | nothing — no FastEmbed reference exists; embeddings come from Gemini |

`VECTOR_SIZE` was the dangerous one: renaming it to the real variable, as its presence invites, would create a 384-dim collection and break every upsert against the 768-dim embeddings.

Added `QDRANT_API_KEY` and `GEMINI_API_KEY`, both previously absent — without the latter the container cannot embed at all.

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` with client 1.19.0 | exit 0 |
| `npm run build` | exit 0 |
| `npm ci` from committed lockfile, clean dir | exit 0, installs 1.19.0 |
| CommonJS `require()` + `new QdrantClient()` | OK, no `ERR_REQUIRE_ESM` |
| `typeof client.search` / `client.query` on 1.19.0 | `undefined` / `function` |
| `docker compose config` | exit 0, resolves as intended |

**Not covered: no runtime test against a live Qdrant.** Everything above is compile-time and module-load. `GET /api/documents/search` needs a smoke test before merge.

When smoke testing, note that `fallback-service.ts:36-39` catches every error indiscriminately and returns the in-memory fallback — a 4xx surfaces as **HTTP 200 with an empty array**. Assert on response content, not status code, and tail logs for `Qdrant unavailable`.

## Still to do outside this PR

- **Qdrant Cloud Backup before upgrading the server.** The upgrade is a one-way door. Note that `POST /api/migrate/backup` is *not* a valid backup for this: it copies a collection into the same cluster being upgraded (`migration.ts:284,345`), so it protects against nothing here.
- `README.md:13,21-22` still claims embeddings use "Qdrant's built-in FastEmbed API" (actually Gemini, 768-dim); `README.md:49-50` lists Node v14 as prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)